### PR TITLE
Replace static player count with number of current proxy clients

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,6 @@
 {
   "motd": "Minecraft VirtualHost Proxy",
   "capacity": 10,
-  "players": 3,
   "hosts": {
     "localhost": {
       "host": "192.168.0.6"

--- a/mvhp.py
+++ b/mvhp.py
@@ -141,7 +141,7 @@ class ClientTunnel(asynchat.async_chat):
         self.bound = False
         self.server = None
         self.addr = "%s:%s" % addr
-        self.log("Incomming connection")
+        self.log("Incoming connection")
 
     def log(self, message):
         '''

--- a/mvhp.py
+++ b/mvhp.py
@@ -167,7 +167,7 @@ class ClientTunnel(asynchat.async_chat):
                 if packetId == 0xfe:        # Handle server list query
                     self.log("Received server list query")
                     self.kick(u"%s§%s§%s" % (config.motd,
-                                            config.players,
+                                            len(server.clients)-1, # Subtract one since connecting to poll server counts as a connection
                                             config.capacity))
                 elif packetId == 0x02:      # Handle handshake
                     if len(self.ibuffer) >= 3:
@@ -288,7 +288,6 @@ class Config:
             raise Exception("Invalid structure")
         self.hosts = self._expand(raw_config.get("hosts", {}))
         self.capacity = raw_config.get("capacity", 0)
-        self.players = raw_config.get("players", 0)
         self.motd = raw_config.get("motd", "Minecraft VirtualHost Proxy")
         print "Loaded %s host definitions" % len(self.hosts)
 


### PR DESCRIPTION
Instead of having a static player count (defined in the config file), report the number of current proxy clients as the number of players.  It's not quite a perfect solution - ideally (given the lack of hostname in the server info request), it'd poll all servers it's proxying for and report the actual number of connected players (and the total number of player slots, too - that's still static for now).  It can potentially report extra players if they poll for info at the exact same time and haven't yet been kicked with the info packet, but the chances are slim and it's still more accurate than a static figure.

This pull request also includes a fix for a very minor typo (as a separate commit).
