### PR TITLE
Compatibility: warn if SIGHUP and/or SIGINFO not supported

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,6 @@
 {
   "motd": "Minecraft VirtualHost Proxy",
   "capacity": 10,
-  "players": 3,
   "hosts": {
     "localhost": {
       "host": "192.168.0.6"

--- a/mvhp.py
+++ b/mvhp.py
@@ -141,7 +141,7 @@ class ClientTunnel(asynchat.async_chat):
         self.bound = False
         self.server = None
         self.addr = "%s:%s" % addr
-        self.log("Incomming connection")
+        self.log("Incoming connection")
 
     def log(self, message):
         '''

--- a/mvhp.py
+++ b/mvhp.py
@@ -345,8 +345,17 @@ if __name__ == "__main__":
         print "Invalid configuration file:"
         print e
         sys.exit(1)
-    signal.signal(signal.SIGHUP, refresh)
-    signal.signal(signal.SIGINFO, info)
+    
+    try:
+        signal.signal(signal.SIGHUP, refresh)
+    except Exception as e:
+        print "NOTICE: SIGHUP not supported on your OS"
+    
+    try:
+        signal.signal(signal.SIGINFO, info)
+    except Exception as e:
+        print "NOTICE: SIGINFO not supported on your OS"
+    
     signal.signal(signal.SIGTERM, terminate)
     signal.signal(signal.SIGINT, terminate)
     server = Listener('0.0.0.0', 25565)

--- a/mvhp.py
+++ b/mvhp.py
@@ -167,7 +167,7 @@ class ClientTunnel(asynchat.async_chat):
                 if packetId == 0xfe:        # Handle server list query
                     self.log("Received server list query")
                     self.kick(u"%s§%s§%s" % (config.motd,
-                                            config.players,
+                                            len(server.clients)-1, # Subtract one since connecting to poll server counts as a connection
                                             config.capacity))
                 elif packetId == 0x02:      # Handle handshake
                     if len(self.ibuffer) >= 3:
@@ -288,7 +288,6 @@ class Config:
             raise Exception("Invalid structure")
         self.hosts = self._expand(raw_config.get("hosts", {}))
         self.capacity = raw_config.get("capacity", 0)
-        self.players = raw_config.get("players", 0)
         self.motd = raw_config.get("motd", "Minecraft VirtualHost Proxy")
         print "Loaded %s host definitions" % len(self.hosts)
 


### PR DESCRIPTION
If SIGHUP and/or SIGINFO not supported, MVHP will fail to start.  This patch catches these exceptions and outputs a warning, continuing to launch but not attaching the relevant handler.

SIGINFO does not appear to be supported on my Ubuntu 11.10 (64-bit) install, which was preventing me from using MVHP - this change may even make it work on Windows, which (according to the Python docs) doesn't support either SIGINFO or SIGHUP.
